### PR TITLE
spdep-devel moves sp from depends to suggests

### DIFF
--- a/tests/nbgraph.R
+++ b/tests/nbgraph.R
@@ -6,7 +6,7 @@ library(lattice)
 pdf("nbgraph.pdf")
 
 data(elec88, package = "ade4")
-coords <- coordinates(elec88$Spatial)
+coords <- sp::coordinates(elec88$Spatial)
 
 xyplot(coords[, 2] ~ coords[, 1],
   		 panel = function(...) {adeg.panel.nb(elec88$nb, coords)})


### PR DESCRIPTION
`tests/nbgraph.R` uses **sp** without requiring it, because **spdep** has depended on **sp**. This is mis-understood as meaning that only `"Spatial"` objects can be used with **spdep**, so **sp** is moving from `Depends:` to `Suggests:` in **spdep**.